### PR TITLE
fix UPDATE example in executeMany comment

### DIFF
--- a/src/Database/PostgreSQL/Simple.hs
+++ b/src/Database/PostgreSQL/Simple.hs
@@ -338,7 +338,7 @@ execute conn template qs = do
 -- @
 -- executeMany c [sql|
 --     UPDATE sometable
---        SET sometable.y = upd.y
+--        SET y = upd.y
 --       FROM (VALUES (?,?)) as upd(x,y)
 --      WHERE sometable.x = upd.x
 --  |] [(1, \"hello\"),(2, \"world\")]


### PR DESCRIPTION
I tried writing a query based on the API doc for `executeMany` and found that running it produces a `SqlError`.

The [PostgreSQL documentation](https://www.postgresql.org/docs/11/sql-update.html) confirms:

> Do not include the table's name in the specification of a target column — for example, `UPDATE table_name SET table_name.col = 1` is invalid.