### PR TITLE
return `ByteString` from `name`, not `Maybe ByteString`

### DIFF
--- a/src/Database/PostgreSQL/Simple/Internal.hs
+++ b/src/Database/PostgreSQL/Simple/Internal.hs
@@ -115,6 +115,15 @@ data FormatError = FormatError {
 
 instance Exception FormatError
 
+
+-- | Exception thrown if libpq returns an error code that we had
+-- intended to prevent statically.  In other words, a bug in the
+-- bindings.
+newtype PQBindingError = PQBindingError T.Text
+    deriving (Eq, Show, Typeable)
+
+instance Exception PQBindingError
+
 data ConnectInfo = ConnectInfo {
       connectHost :: String
     , connectPort :: Word16


### PR DESCRIPTION
This PR is related in spirit, but not in implementation, to my last two.  Here, the situation is reversed - the old version asks the library user to handle a @Nothing@ which I believe can only happen if the `Field` is constructed outside of `postgresql-simple`.  I generally prefer exceptions in these situations, since they're easy to ignore, but can still be caught if I'm wrong & this case can occur.

What do you think?