### PR TITLE
Generalize operations to be amenable to monad stacks

### DIFF
--- a/postgresql-simple.cabal
+++ b/postgresql-simple.cabal
@@ -79,6 +79,7 @@ library
       base              >=4.6.0.0  && <4.14
     , bytestring        >=0.10.0.0 && <0.11
     , containers        >=0.5.0.0  && <0.7
+    , exceptions        >=0.10.4   && <0.11
     , template-haskell  >=2.8.0.0  && <2.16
     , text              >=1.2.3.0  && <1.3
     , time              >=1.4.0.1  && <1.10


### PR DESCRIPTION
A few operations are of the variety that make people reach for MonadUnliftIO and other horrors.  By using the `exceptions` version of `mask` and `throwM` we can make more generic transaction calls.

In general, calls in the form:

```
f :: a -> IO b -> IO c
```

are now

```
f  :: (MonadIO m, MonadMask m) => a -> m b -> m c
```

So that we don't need to copy out the full function definition when making a transformer that includes an SQL connection and transaction.

Calls in the form:

```
f :: a -> IO b
```

Remain IO - transformer stacks rarely would be making low level calls and can freely use `liftIO` for these cases.

This branch fails no worse than the current master, which is failing two tests currently.